### PR TITLE
gl2 v0.9.6 timestamp issue

### DIFF
--- a/src/main/groovy/com/pstehlik/groovy/gelf4j/appender/Gelf4JAppender.groovy
+++ b/src/main/groovy/com/pstehlik/groovy/gelf4j/appender/Gelf4JAppender.groovy
@@ -109,6 +109,7 @@ extends AppenderSkeleton {
     if (shortMessage.length() > SHORT_MESSAGE_LENGTH) {
       shortMessage = shortMessage.substring(0, SHORT_MESSAGE_LENGTH)
     }
+    int gelfTimeStamp = Math.floor(loggingEvent.getTimeStamp() / 1000)
     def gelfMessage = [
       "facility": facility ?: 'GELF',
       "file": '',
@@ -117,7 +118,7 @@ extends AppenderSkeleton {
       "level": "${loggingEvent.getLevel().getSyslogEquivalent()}" as String,
       "line": '',
       "short_message": shortMessage,
-      "timestamp": loggingEvent.getTimeStamp(),
+      "timestamp": gelfTimeStamp as String,
       "version": GELF_VERSION
     ]
     //only set location information if configured

--- a/src/test/groovy/com/pstehlik/groovy/gelf4j/appender/Gelf4JAppenderTests.groovy
+++ b/src/test/groovy/com/pstehlik/groovy/gelf4j/appender/Gelf4JAppenderTests.groovy
@@ -52,7 +52,8 @@ extends BaseUnitTest{
     assertEquals '4', res.level
     assertEquals '', res.line
     assert res.short_message.contains('someMessage')
-    assertEquals le.getTimeStamp(), res.timestamp
+    int gelfTimeStamp = Math.floor(le.getTimeStamp() / 1000)
+    assertEquals gelfTimeStamp as String, res.timestamp
     assertEquals '1.0', res.version
   }
 


### PR DESCRIPTION
Fixed timestamp issue which occurs when gelf4j is used with gl2 v0.9.6. The gelf specifications require a unix timestamp in seconds instead of milliseconds as given by loggingEvent.getTimeStamp(). Divided loggingEvent.getTimeStamp() by a 1000 and floored it. Made the change in the test suite as well to make sure they pass.
