### PR TITLE
Chunked messages header fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'groovy'
+apply plugin: 'maven'
 apply plugin: 'idea'
-version = 0.86
+version = '0.86'
 
+group='org.graylog2'
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
Iv fixed the chunked header implementation for graylog2-server, the current gelf4j implementation uses 36 characters for the header while the current spec  supports only 12, iv followed the same algorithm as the gelf4r implementation (using md5 on the current time) and verified the the graylog2 server works, 

Best regards 
Ronen
