### PR TITLE
Support adding log4j MDC fields to gelf additional fields

### DIFF
--- a/README
+++ b/README
@@ -60,6 +60,9 @@ Default: false (for backwards compatibility)
 The amount of bytes a message chunk can contain.
 Default: 8154
 
+'mdcFields'
+A list of fields to read from log4j MDC and append to the additional fields
+
 ---
 
 A working example of a GELF appender in a log4j.properties file would be

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'groovy'
 apply plugin: 'idea'
-version = "0.9.6"
+version = "0.9.7"
 
 repositories {
     mavenCentral()

--- a/src/main/groovy/com/pstehlik/groovy/gelf4j/appender/Gelf4JAppender.groovy
+++ b/src/main/groovy/com/pstehlik/groovy/gelf4j/appender/Gelf4JAppender.groovy
@@ -37,6 +37,7 @@ extends AppenderSkeleton {
   public Boolean includeLocationInformation = false
   public Boolean logStackTraceFromMessage = false
   public Integer maxChunkSize = 8154
+  public List mdcFields = null
   //---------------------------------------
 
   private GelfTransport _gelfTransport
@@ -139,6 +140,16 @@ extends AppenderSkeleton {
         }
       }
     }
+
+    if (mdcFields != null) {
+      mdcFields.each {
+        def mdcValue = loggingEvent.getMDC(it)
+        if (mdcValue != null) {
+          gelfMessage['_' + it] = mdcValue as String
+        }
+      }
+    }
+
     return gelfMessage
   }
 
@@ -199,6 +210,10 @@ extends AppenderSkeleton {
 
   public void setLogStackTraceFromMessage(String trueFalse) {
     logStackTraceFromMessage = Boolean.parseBoolean(trueFalse)
+  }
+
+  public void setMdcFields(List mdcFields) {
+    this.mdcFields = mdcFields
   }
 
   private Integer getMaxLoggedLines() {

--- a/src/test/groovy/com/pstehlik/groovy/gelf4j/appender/Gelf4JAppenderTests.groovy
+++ b/src/test/groovy/com/pstehlik/groovy/gelf4j/appender/Gelf4JAppenderTests.groovy
@@ -1,5 +1,6 @@
 package com.pstehlik.groovy.gelf4j.appender
 
+import org.apache.log4j.MDC
 import org.junit.Test
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNull
@@ -187,5 +188,26 @@ some long message. some long message. some long message. some long message. some
     }
     def res = appender.append(null)
     assertNull res
+  }
+
+  @Test
+  void testMdcFields() {
+    appender.mdcFields = ['mdc', 'someField']
+
+    MDC.put('someField', 100)
+
+    LoggingEvent le = new LoggingEvent(
+      this.class.name,
+      cat,
+      Priority.WARN,
+      'someMessage',
+      null
+    )
+
+    def res = appender.createGelfMapFromLoggingEvent(le)
+
+    assert res._someField == '100'
+    assert !res.containsKey('_mdc')
+
   }
 }


### PR DESCRIPTION
Adds a list of fields to Gelf4JAppender, if these fields are present in Log4J's MDC context they will be added as additional fields to the gelf payload.

The MDC value is coerced into a string.
